### PR TITLE
NewRect variable names

### DIFF
--- a/point.go
+++ b/point.go
@@ -209,8 +209,9 @@ type Rect struct {
 }
 
 // NewRect creates a new rectangle
-func NewRect(left, top, bottom, right int16) Rect {
-	return Rect{Min: At(left, top), Max: At(bottom, right)}
+// left,top,right,bottom correspond to x1,y1,x2,y2
+func NewRect(left, top, right, bottom int16) Rect {
+	return Rect{Min: At(left, top), Max: At(right, bottom)}
 }
 
 // Contains returns whether a point is within the rectangle or not.


### PR DESCRIPTION
I think there was a typo in the variable names for `NewRect` that was a bit confusing when looking at the documentation. Based on how the variables are being used by `At` I think the names "right" and "bottom" need to be switched.