### PR TITLE
Migrate to 1.17 and iostream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/kelindar/tile
 
-go 1.16
+go 1.17
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/kelindar/iostream v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kelindar/iostream v1.2.0 h1:UaFLsj/0quGMZxI/rpHmI8u7vNKY9xSyw4mQ9YCTPWA=
+github.com/kelindar/iostream v1.2.0/go.mod h1:MkjMuVb6zGdPQVdwLnFRO0xOTOdDvBWTztFmjRDQkXk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/grid_test.go
+++ b/grid_test.go
@@ -10,12 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// BenchmarkGrid/each-8         	     524	   2272672 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkGrid/neighbors-8    	17840230	        69.34 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkGrid/within-8       	   18727	     64443 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkGrid/at-8           	61221052	        18.31 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkGrid/write-8        	59267746	        18.01 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkGrid/merge-8        	49427276	        23.88 ns/op	       0 B/op	       0 allocs/op
+/*
+cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
+BenchmarkGrid/each-8         	     698	   1694002 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGrid/neighbors-8    	19652220	        66.16 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGrid/within-8       	   26200	     47040 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGrid/at-8           	59190276	        16.96 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGrid/write-8        	100000000	        15.40 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGrid/merge-8        	52110926	        23.06 ns/op	       0 B/op	       0 allocs/op
+*/
 func BenchmarkGrid(b *testing.B) {
 	var d [6]byte
 	var p Point

--- a/store_test.go
+++ b/store_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// BenchmarkStore/save-8         	    6327	    188285 ns/op	       8 B/op	       1 allocs/op
-// BenchmarkStore/read-8         	    2380	    471609 ns/op	  651594 B/op	       8 allocs/op
+/*
+cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
+BenchmarkStore/save-8         	    9068	    129974 ns/op	       8 B/op	       1 allocs/op
+BenchmarkStore/read-8         	    2967	    379663 ns/op	  647465 B/op	       8 allocs/op
+*/
 func BenchmarkStore(b *testing.B) {
 	m := mapFrom("300x300.png")
 


### PR DESCRIPTION
This PR migrates the go version to `v1.17` and updates to use `kelindar/iostream` for encoding/decoding.