### PR TITLE
Add direction and move to point

### DIFF
--- a/path_test.go
+++ b/path_test.go
@@ -94,6 +94,24 @@ func BenchmarkPath(b *testing.B) {
 		}
 	})
 
+	b.Run("3069x3069", func(b *testing.B) {
+		m := NewGrid(3069, 3069)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			m.Path(At(0, 0), At(700, 700), costOf)
+		}
+	})
+
+	b.Run("3072x3072", func(b *testing.B) {
+		m := NewGrid(3072, 3072)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			m.Path(At(0, 0), At(700, 700), costOf)
+		}
+	})
+
 	b.Run("6144x6144", func(b *testing.B) {
 		m := NewGrid(6144, 6144)
 		b.ReportAllocs()
@@ -102,16 +120,6 @@ func BenchmarkPath(b *testing.B) {
 			m.Path(At(0, 0), At(380, 380), costOf)
 		}
 	})
-
-	b.Run("6147x6147", func(b *testing.B) {
-		m := NewGrid(6147, 6147)
-		b.ReportAllocs()
-		b.ResetTimer()
-		for n := 0; n < b.N; n++ {
-			m.Path(At(0, 0), At(380, 380), costOf)
-		}
-	})
-
 }
 
 // BenchmarkAround/3r-8         	  352876	      3355 ns/op	     385 B/op	       1 allocs/op

--- a/point.go
+++ b/point.go
@@ -188,6 +188,35 @@ func (p Point) WithinSize(size Point) bool {
 	return p.X >= 0 && p.Y >= 0 && p.X < size.X && p.Y < size.Y
 }
 
+// Move moves a point by one in the specified direction.
+func (p Point) Move(direction Direction) Point {
+	return p.MoveBy(direction, 1)
+}
+
+// MoveBy moves a point by n in the specified direction.
+func (p Point) MoveBy(direction Direction, n int16) Point {
+	switch direction {
+	case North:
+		return Point{p.X, p.Y + n}
+	case NorthEast:
+		return Point{p.X + n, p.Y + n}
+	case East:
+		return Point{p.X + n, p.Y}
+	case SouthEast:
+		return Point{p.X + n, p.Y - n}
+	case South:
+		return Point{p.X, p.Y - n}
+	case SouthWest:
+		return Point{p.X - n, p.Y - n}
+	case West:
+		return Point{p.X - n, p.Y}
+	case NorthWest:
+		return Point{p.X - n, p.Y + n}
+	default:
+		return p
+	}
+}
+
 // DistanceTo calculates manhattan distance to the other point
 func (p Point) DistanceTo(other Point) uint32 {
 	return abs(int32(p.X)-int32(other.X)) + abs(int32(p.Y)-int32(other.Y))
@@ -229,5 +258,46 @@ func (r *Rect) Size() Point {
 	return Point{
 		X: r.Max.X - r.Min.X,
 		Y: r.Max.Y - r.Min.Y,
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+// Diretion represents a direction
+type Direction byte
+
+// Various directions
+const (
+	North Direction = iota
+	NorthEast
+	East
+	SouthEast
+	South
+	SouthWest
+	West
+	NorthWest
+)
+
+// String returns a string representation of a direction
+func (v Direction) String() string {
+	switch v {
+	case North:
+		return "🡱N"
+	case NorthEast:
+		return "🡵NE"
+	case East:
+		return "🡲E"
+	case SouthEast:
+		return "🡶SE"
+	case South:
+		return "🡳S"
+	case SouthWest:
+		return "🡷SW"
+	case West:
+		return "🡰W"
+	case NorthWest:
+		return "🡴NW"
+	default:
+		return ""
 	}
 }

--- a/point_test.go
+++ b/point_test.go
@@ -9,37 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPoint(t *testing.T) {
-	p := At(10, 20)
-	p2 := At(2, 2)
-
-	assert.Equal(t, int16(10), p.X)
-	assert.Equal(t, int16(20), p.Y)
-	assert.Equal(t, uint32(0xa0014), p.Integer())
-	assert.Equal(t, At(-5, 5), unpackPoint(At(-5, 5).Integer()))
-	assert.Equal(t, "10,20", p.String())
-	assert.True(t, p.Equal(At(10, 20)))
-	assert.Equal(t, "20,40", p.MultiplyScalar(2).String())
-	assert.Equal(t, "5,10", p.DivideScalar(2).String())
-	assert.Equal(t, "12,22", p.Add(p2).String())
-	assert.Equal(t, "8,18", p.Subtract(p2).String())
-	assert.Equal(t, "20,40", p.Multiply(p2).String())
-	assert.Equal(t, "5,10", p.Divide(p2).String())
-	assert.True(t, p.Within(At(1, 1), At(10, 20)))
-	assert.True(t, p.WithinRect(NewRect(1, 1, 10, 20)))
-	assert.False(t, p.WithinSize(At(10, 20)))
-	assert.True(t, p.WithinSize(At(20, 30)))
-}
-
-func TestMorton(t *testing.T) {
-	p := At(8191, 8191)
-	assert.Equal(t, 67108863, int(p.Interleave()))
-	assert.Equal(t, p, deinterleavePoint(67108863))
-}
-
-// BenchmarkPoint/within-8         	1000000000	         0.220 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkPoint/within-rect-8    	1000000000	         0.219 ns/op	       0 B/op	       0 allocs/op
-// BenchmarkPoint/interleave-8     	1000000000	         0.657 ns/op	       0 B/op	       0 allocs/op
+/*
+cpu: Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
+BenchmarkPoint/within-8         	1000000000	         0.2697 ns/op	       0 B/op	       0 allocs/op
+BenchmarkPoint/within-rect-8    	1000000000	         0.2928 ns/op	       0 B/op	       0 allocs/op
+BenchmarkPoint/interleave-8     	1000000000	         0.8242 ns/op	       0 B/op	       0 allocs/op
+*/
 func BenchmarkPoint(b *testing.B) {
 	p := At(10, 20)
 	b.Run("within", func(b *testing.B) {
@@ -68,4 +43,65 @@ func BenchmarkPoint(b *testing.B) {
 		}
 		assert.NotZero(b, out)
 	})
+}
+
+func TestPoint(t *testing.T) {
+	p := At(10, 20)
+	p2 := At(2, 2)
+
+	assert.Equal(t, int16(10), p.X)
+	assert.Equal(t, int16(20), p.Y)
+	assert.Equal(t, uint32(0xa0014), p.Integer())
+	assert.Equal(t, At(-5, 5), unpackPoint(At(-5, 5).Integer()))
+	assert.Equal(t, "10,20", p.String())
+	assert.True(t, p.Equal(At(10, 20)))
+	assert.Equal(t, "20,40", p.MultiplyScalar(2).String())
+	assert.Equal(t, "5,10", p.DivideScalar(2).String())
+	assert.Equal(t, "12,22", p.Add(p2).String())
+	assert.Equal(t, "8,18", p.Subtract(p2).String())
+	assert.Equal(t, "20,40", p.Multiply(p2).String())
+	assert.Equal(t, "5,10", p.Divide(p2).String())
+	assert.True(t, p.Within(At(1, 1), At(10, 20)))
+	assert.True(t, p.WithinRect(NewRect(1, 1, 10, 20)))
+	assert.False(t, p.WithinSize(At(10, 20)))
+	assert.True(t, p.WithinSize(At(20, 30)))
+}
+
+func TestMorton(t *testing.T) {
+	p := At(8191, 8191)
+	assert.Equal(t, 67108863, int(p.Interleave()))
+	assert.Equal(t, p, deinterleavePoint(67108863))
+}
+
+func TestDirection(t *testing.T) {
+	for i := 0; i < 8; i++ {
+		dir := Direction(i)
+		assert.NotEmpty(t, dir.String())
+	}
+}
+
+func TestDirection_Empty(t *testing.T) {
+	dir := Direction(9)
+	assert.Empty(t, dir.String())
+}
+
+func TestMove(t *testing.T) {
+	tests := []struct {
+		dir Direction
+		out Point
+	}{
+		{North, Point{X: 0, Y: 1}},
+		{South, Point{X: 0, Y: -1}},
+		{East, Point{X: 1, Y: 0}},
+		{West, Point{X: -1, Y: 0}},
+		{NorthEast, Point{X: 1, Y: 1}},
+		{NorthWest, Point{X: -1, Y: 1}},
+		{SouthEast, Point{X: 1, Y: -1}},
+		{SouthWest, Point{X: -1, Y: -1}},
+		{Direction(99), Point{}},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.out, Point{}.Move(tc.dir), tc.dir.String())
+	}
 }


### PR DESCRIPTION
This PR adds a `Direction` enumeration as well as `Point.Move(Direction) Point` and  `Point.MoveBy(Direction, int16) Point`  which allows to translate a point to a certain direction.