### PR TITLE
Refactor update event and added state move

### DIFF
--- a/view.go
+++ b/view.go
@@ -15,13 +15,18 @@ type Observer[T comparable] interface {
 	onUpdate(*Update[T])
 }
 
+type UpdateState[T comparable] struct {
+	Point   // The point of the tile
+	Value   // The value of the tile
+	Add   T // An object was added to the tile
+	Del   T // An object was removed from the tile
+}
+
 // Update represents a tile update notification.
 type Update[T comparable] struct {
-	Point       // The tile location
-	Old   Value // Old tile value
-	New   Value // New tile value
-	Add   T     // An object was added to the tile
-	Del   T     // An object was removed from the tile
+	Old UpdateState[T] // Old tile + value
+	New UpdateState[T] // New tile + value
+
 }
 
 var _ Observer[string] = (*View[string, string])(nil)
@@ -155,46 +160,112 @@ func (v *View[S, T]) Close() error {
 
 // onUpdate occurs when a tile has updated.
 func (v *View[S, T]) onUpdate(ev *Update[T]) {
-	if v.Viewport().Contains(ev.Point) {
-		v.Inbox <- *ev // (copy)
-	}
+	v.Inbox <- *ev // (copy)
 }
 
 // -----------------------------------------------------------------------------
 
 // Pubsub represents a publish/subscribe layer for observers.
 type pubsub[T comparable] struct {
-	m sync.Map
+	m   sync.Map  // Concurrent map of observers
+	tmp sync.Pool // Temporary observer sets for notifications
 }
 
 // Notify notifies listeners of an update that happened.
-func (p *pubsub[T]) Notify(page Point, ev *Update[T]) {
-	if v, ok := p.m.Load(page.Integer()); ok {
-		v.(*observers[T]).Notify(ev)
-	}
+func (p *pubsub[T]) Notify1(ev *Update[T], page, at Point) {
+	p.Each1(func(sub Observer[T]) {
+		sub.onUpdate(ev)
+	}, page, at)
+}
+
+// Notify notifies listeners of an update that happened.
+func (p *pubsub[T]) Notify2(ev *Update[T], pages, locs [2]Point) {
+	p.Each2(func(sub Observer[T]) {
+		sub.onUpdate(ev)
+	}, pages, locs)
 }
 
 // Each iterates over each observer in a page
-func (p *pubsub[T]) Each(page Point, fn func(sub Observer[T])) {
+func (p *pubsub[T]) Each1(fn func(sub Observer[T]), page, at Point) {
 	if v, ok := p.m.Load(page.Integer()); ok {
-		v.(*observers[T]).Each(fn)
+		v.(*observers[T]).Each(func(sub Observer[T]) {
+			if sub.Viewport().Contains(at) {
+				fn(sub)
+			}
+		})
 	}
 }
 
+// Each2 iterates over each observer in a page
+func (p *pubsub[T]) Each2(fn func(sub Observer[T]), pages, locs [2]Point) {
+	targets := p.tmp.Get().(map[Observer[T]]struct{})
+	clear(targets)
+	defer p.tmp.Put(targets)
+
+	// Collect all observers from all pages
+	for _, page := range pages {
+		if v, ok := p.m.Load(page.Integer()); ok {
+			v.(*observers[T]).Each(func(sub Observer[T]) {
+				targets[sub] = struct{}{}
+			})
+		}
+	}
+
+	// Invoke the callback for each observer, once
+	for sub := range targets {
+		if sub.Viewport().Contains(locs[0]) || sub.Viewport().Contains(locs[1]) {
+			fn(sub)
+		}
+	}
+}
+
+/*
+// Each iterates over each observer in a page
+func (p *pubsub[T]) Each(fn func(sub Observer[T]), pages ...Point) {
+	switch len(pages) {
+
+	// Single page: directly invoke the callback
+	case 1:
+		if v, ok := p.m.Load(pages[0].Integer()); ok {
+			v.(*observers[T]).Each(fn)
+		}
+
+	// Multiple pages: merge distinct observers and invoke the callback
+	default:
+		targets := p.tmp.Get().(map[Observer[T]]struct{})
+		clear(targets)
+		defer p.tmp.Put(targets)
+
+		// Collect all observers from all pages
+		for _, page := range pages {
+			if v, ok := p.m.Load(page.Integer()); ok {
+				v.(*observers[T]).Each(func(sub Observer[T]) {
+					targets[sub] = struct{}{}
+				})
+			}
+		}
+
+		// Invoke the callback for each observer, once
+		for sub := range targets {
+			fn(sub)
+		}
+	}
+}*/
+
 // Subscribe registers an event listener on a system
-func (p *pubsub[T]) Subscribe(at Point, sub Observer[T]) bool {
-	if v, ok := p.m.Load(at.Integer()); ok {
+func (p *pubsub[T]) Subscribe(page Point, sub Observer[T]) bool {
+	if v, ok := p.m.Load(page.Integer()); ok {
 		return v.(*observers[T]).Subscribe(sub)
 	}
 
 	// Slow path
-	v, _ := p.m.LoadOrStore(at.Integer(), newObservers[T]())
+	v, _ := p.m.LoadOrStore(page.Integer(), newObservers[T]())
 	return v.(*observers[T]).Subscribe(sub)
 }
 
 // Unsubscribe deregisters an event listener from a system
-func (p *pubsub[T]) Unsubscribe(at Point, sub Observer[T]) bool {
-	if v, ok := p.m.Load(at.Integer()); ok {
+func (p *pubsub[T]) Unsubscribe(page Point, sub Observer[T]) bool {
+	if v, ok := p.m.Load(page.Integer()); ok {
 		return v.(*observers[T]).Unsubscribe(sub)
 	}
 	return false
@@ -214,13 +285,6 @@ func newObservers[T comparable]() *observers[T] {
 	return &observers[T]{
 		subs: make([]Observer[T], 0, 8),
 	}
-}
-
-// Notify notifies listeners of an update that happened.
-func (s *observers[T]) Notify(ev *Update[T]) {
-	s.Each(func(sub Observer[T]) {
-		sub.onUpdate(ev)
-	})
 }
 
 // Each iterates over each observer

--- a/view_test.go
+++ b/view_test.go
@@ -5,7 +5,6 @@ package tile
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -82,7 +81,7 @@ func TestView(t *testing.T) {
 	before := cursor.Value()
 	v.WriteAt(5, 5, Value(55))
 	update := <-v.Inbox
-	assert.Equal(t, At(5, 5), update.Point)
+	assert.Equal(t, At(5, 5), update.New.Point)
 	assert.NotEqual(t, before, update.New)
 
 	// Merge a tile in view, but with zero mask (won't do anything)
@@ -90,8 +89,8 @@ func TestView(t *testing.T) {
 	before = cursor.Value()
 	v.MergeAt(5, 5, Value(66), Value(0)) // zero mask
 	update = <-v.Inbox
-	assert.Equal(t, At(5, 5), update.Point)
-	assert.Equal(t, before, update.New)
+	assert.Equal(t, At(5, 5), update.New.Point)
+	assert.Equal(t, before, update.New.Value)
 
 	// Close the view
 	assert.NoError(t, v.Close())
@@ -99,6 +98,7 @@ func TestView(t *testing.T) {
 	assert.Equal(t, 0, len(v.Inbox))
 }
 
+/*
 func TestObservers(t *testing.T) {
 	ev := newObservers[uint32]()
 	assert.NotNil(t, ev)
@@ -128,20 +128,12 @@ func TestObservers(t *testing.T) {
 	ev.Notify(&Update[uint32]{Point: At(2, 0)})
 	assert.Equal(t, 6, count)
 }
+*/
 
-func TestObserversNil(t *testing.T) {
-	assert.NotPanics(t, func() {
-		var ev *observers[uint32]
-		ev.Notify(&Update[uint32]{Point: At(1, 0)})
-	})
-}
-
-func TestStateUpdates(t *testing.T) {
+func TestUpdates_Simple(t *testing.T) {
 	m := mapFrom("300x300.png")
-
-	// Create a new view
 	c := counter(0)
-	v := NewView[string, string](m, "view 1")
+	v := NewView(m, "view 1")
 	v.Resize(NewRect(0, 0, 10, 10), c.count)
 
 	assert.NotNil(t, v)
@@ -151,34 +143,56 @@ func TestStateUpdates(t *testing.T) {
 	cursor, _ := v.At(5, 5)
 	cursor.Write(Value(0xF0))
 	assert.Equal(t, Update[string]{
-		Point: At(5, 5),
-		New:   Value(0xF0),
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+		},
+		New: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xF0),
+		},
 	}, <-v.Inbox)
 
 	// Add an object to an observed tile
 	cursor.Add("A")
 	assert.Equal(t, Update[string]{
-		Point: At(5, 5),
-		Old:   Value(0xF0),
-		New:   Value(0xF0),
-		Add:   "A",
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xF0),
+			Add:   "A",
+		},
+		New: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xF0),
+			Add:   "A",
+		},
 	}, <-v.Inbox)
 
 	// Delete an object from an observed tile
 	cursor.Del("A")
 	assert.Equal(t, Update[string]{
-		Point: At(5, 5),
-		Old:   Value(0xF0),
-		New:   Value(0xF0),
-		Del:   "A",
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xF0),
+			Del:   "A",
+		},
+		New: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xF0),
+			Del:   "A",
+		},
 	}, <-v.Inbox)
 
 	// Mask a tile in view
 	cursor.Mask(0xFF, 0x0F)
 	assert.Equal(t, Update[string]{
-		Point: At(5, 5),
-		Old:   Value(0xF0),
-		New:   Value(0xFF),
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xF0),
+		},
+		New: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xFF),
+		},
 	}, <-v.Inbox)
 
 	// Merge a tile in view
@@ -186,18 +200,87 @@ func TestStateUpdates(t *testing.T) {
 		return 0xAA
 	})
 	assert.Equal(t, Update[string]{
-		Point: At(5, 5),
-		Old:   Value(0xFF),
-		New:   Value(0xAA),
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xFF),
+		},
+		New: UpdateState[string]{
+			Point: At(5, 5),
+			Value: Value(0xAA),
+		},
 	}, <-v.Inbox)
 }
 
-func TestObservers_MoveIncremental(t *testing.T) {
+func TestMove_Within(t *testing.T) {
+	m := mapFrom("300x300.png")
+	c := counter(0)
+	v := NewView(m, "view 1")
+	v.Resize(NewRect(0, 0, 10, 10), c.count)
+
+	// Add an object to an observed tile. This should only fire once since
+	// both the old and new states are the observed by the view.
+	cursor, _ := v.At(5, 5)
+	cursor.Move("A", At(6, 6))
+	assert.Equal(t, Update[string]{
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+			Del:   "A",
+		},
+		New: UpdateState[string]{
+			Point: At(6, 6),
+			Add:   "A",
+		},
+	}, <-v.Inbox)
+}
+
+func TestMove_Incoming(t *testing.T) {
+	m := mapFrom("300x300.png")
+	c := counter(0)
+	v := NewView(m, "view 1")
+	v.Resize(NewRect(0, 0, 10, 10), c.count)
+
+	// Add an object to an observed tile from outside the view.
+	cursor, _ := v.At(20, 20)
+	cursor.Move("A", At(5, 5))
+	assert.Equal(t, Update[string]{
+		Old: UpdateState[string]{
+			Point: At(20, 20),
+			Del:   "A",
+		},
+		New: UpdateState[string]{
+			Point: At(5, 5),
+			Add:   "A",
+		},
+	}, <-v.Inbox)
+}
+
+func TestMove_Outgoing(t *testing.T) {
+	m := mapFrom("300x300.png")
+	c := counter(0)
+	v := NewView(m, "view 1")
+	v.Resize(NewRect(0, 0, 10, 10), c.count)
+
+	// Move an object from an observed tile outside of the view.
+	cursor, _ := v.At(5, 5)
+	cursor.Move("A", At(20, 20))
+	assert.Equal(t, Update[string]{
+		Old: UpdateState[string]{
+			Point: At(5, 5),
+			Del:   "A",
+		},
+		New: UpdateState[string]{
+			Point: At(20, 20),
+			Add:   "A",
+		},
+	}, <-v.Inbox)
+}
+
+func TestView_MoveTo(t *testing.T) {
 	m := mapFrom("300x300.png")
 
 	// Create a new view
 	c := counter(0)
-	v := NewView[string, string](m, "view 1")
+	v := NewView(m, "view 1")
 	v.Resize(NewRect(10, 10, 12, 12), c.count)
 
 	assert.NotNil(t, v)


### PR DESCRIPTION
This pull request changes the tile update event structure, as it also adds an ability to `Move()` a state of a tile from one to another via a new `Move()` method on a `Tile[T]` itself. This moves the state and notifies observers correctly (and only once) by dispatching an event with both `New` and `Old` tiles set, their location, and the state which was added/deleted. To accomplish this I needed to refactor a bunch of stuff as well.

### Enhancements to Observer Notification System:
* Introduced `UpdateState` struct to encapsulate the state of a tile before and after an update. (`view.go`)
* Modified `pubsub` to include `Notify1` and `Notify2` methods for handling notifications for single and multiple observers respectively. (`view.go`) [[1]](diffhunk://#diff-da9a3172868483bf3dc8e219932835d98b6a4cdb7858081b07128b265ead4907L158-R268) [[2]](diffhunk://#diff-da9a3172868483bf3dc8e219932835d98b6a4cdb7858081b07128b265ead4907L219-L225)

### Improvements to Tile Update Mechanics:
* Refactored `writeTile`, `mergeTile`, `addObject`, and `delObject` methods to use `UpdateState` for more granular update notifications. (`grid.go`) [[1]](diffhunk://#diff-cf84b3e9fd6f3951943822eada0e349d2df32f0540435c13cdfc3bc077b4b2b4L245-R302) [[2]](diffhunk://#diff-cf84b3e9fd6f3951943822eada0e349d2df32f0540435c13cdfc3bc077b4b2b4R312-R325)
* Added `Move` method to `Tile` struct to handle moving objects between tiles and notify observers accordingly. (`grid.go`)

