### PR TITLE
Improved pathfinding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kelindar/tile
 go 1.23
 
 require (
+	github.com/kelindar/intmap v1.4.1
 	github.com/kelindar/iostream v1.4.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kelindar/intmap v1.4.1 h1:3jTPTrfNx4pxBPURR1+6f4YhbZS57CzsU0S9NEV51ZI=
+github.com/kelindar/intmap v1.4.1/go.mod h1:NkypxhfaklmDTJqwano3Q1BWk6je77qgQwszDwu8Kc8=
 github.com/kelindar/iostream v1.4.0 h1:ELKlinnM/K3GbRp9pYhWuZOyBxMMlYAfsOP+gauvZaY=
 github.com/kelindar/iostream v1.4.0/go.mod h1:MkjMuVb6zGdPQVdwLnFRO0xOTOdDvBWTztFmjRDQkXk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/path_test.go
+++ b/path_test.go
@@ -4,6 +4,7 @@
 package tile
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -19,14 +20,16 @@ func TestPath(t *testing.T) {
 	path, dist, found := m.Path(At(1, 1), At(7, 7), costOf)
 	assert.Equal(t, `
 .........
-. x .   .
-. x... ..
-. xxx. ..
-... x.  .
-.   xx  .
+.x  .   .
+.x ... ..
+.xxx . ..
+...x .  .
+.  xxx  .
 .....x...
-.    xx .
+.    xxx.
 .........`, plotPath(m, path))
+
+	fmt.Println(plotPath(m, path))
 	assert.Equal(t, 12, dist)
 	assert.True(t, found)
 }
@@ -35,12 +38,12 @@ func TestPathTiny(t *testing.T) {
 	m := NewGrid(6, 6)
 	path, dist, found := m.Path(At(0, 0), At(5, 5), costOf)
 	assert.Equal(t, `
- x    
- x    
- x    
- x    
- x    
- xxxx `, plotPath(m, path))
+x     
+x     
+x     
+x     
+x     
+xxxxxx`, plotPath(m, path))
 	assert.Equal(t, 10, dist)
 	assert.True(t, found)
 }
@@ -51,12 +54,15 @@ func TestDraw(t *testing.T) {
 	assert.NotNil(t, out)
 }
 
-// BenchmarkPath/9x9-8         	  210472	      5316 ns/op	   16468 B/op	       3 allocs/op
-// BenchmarkPath/300x300-8     	     463	   2546373 ns/op	 7801135 B/op	       4 allocs/op
-// BenchmarkPath/381x381-8     	     373	   2732657 ns/op	62394362 B/op	       4 allocs/op
-// BenchmarkPath/384x384-8     	     153	   7791925 ns/op	62396304 B/op	       5 allocs/op
-// BenchmarkPath/6144x6144-8   	     158	   7468206 ns/op	62395377 B/op	       3 allocs/op
-// BenchmarkPath/6147x6147-8   	     160	   7468716 ns/op	62395359 B/op	       3 allocs/op
+/*
+BenchmarkPath/9x9-24         	 2704395	       440.4 ns/op	     256 B/op	       1 allocs/op
+BenchmarkPath/300x300-24     	    1134	   1033808 ns/op	    3845 B/op	       4 allocs/op
+BenchmarkPath/381x381-24     	    2782	    377676 ns/op	    7298 B/op	       5 allocs/op
+BenchmarkPath/384x384-24     	    2716	    382663 ns/op	    7298 B/op	       5 allocs/op
+BenchmarkPath/3069x3069-24   	     847	   1368243 ns/op	  100140 B/op	       7 allocs/op
+BenchmarkPath/3072x3072-24   	     849	   1368387 ns/op	   99954 B/op	       7 allocs/op
+BenchmarkPath/6144x6144-24   	    3050	    387195 ns/op	   12802 B/op	       5 allocs/op
+*/
 func BenchmarkPath(b *testing.B) {
 	b.Run("9x9", func(b *testing.B) {
 		m := mapFrom("9x9.png")
@@ -122,9 +128,12 @@ func BenchmarkPath(b *testing.B) {
 	})
 }
 
-// BenchmarkAround/3r-8         	  352876	      3355 ns/op	     385 B/op	       1 allocs/op
-// BenchmarkAround/5r-8         	  162103	      7551 ns/op	     931 B/op	       2 allocs/op
-// BenchmarkAround/10r-8        	   62491	     19235 ns/op	    3489 B/op	       2 allocs/op
+/*
+cpu: 13th Gen Intel(R) Core(TM) i7-13700K
+BenchmarkAround/3r-24 	 2080566	     562.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAround/5r-24 	  885582	      1358 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAround/10r-24    300672	      3953 ns/op	       0 B/op	       0 allocs/op
+*/
 func BenchmarkAround(b *testing.B) {
 	m := mapFrom("300x300.png")
 	b.Run("3r", func(b *testing.B) {
@@ -175,38 +184,19 @@ func TestAroundMiss(t *testing.T) {
 	})
 }
 
-// BenchmarkHeap-8   	   94454	     12303 ns/op	    3968 B/op	       5 allocs/op
+/*
+cpu: 13th Gen Intel(R) Core(TM) i7-13700K
+BenchmarkHeap-24    	  240228	      5076 ns/op	    6016 B/op	      68 allocs/op
+*/
 func BenchmarkHeap(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		h := newHeap32(16)
+		h := newFrontier()
 		for j := 0; j < 128; j++ {
 			h.Push(rand(j), 1)
 		}
 		for j := 0; j < 128*10; j++ {
 			h.Push(rand(j), 1)
 			h.Pop()
-		}
-	}
-}
-
-func TestHeap(t *testing.T) {
-	h := newHeap32(16)
-	h.Push(1, 0)
-	h.Pop()
-}
-
-func TestNewHeap(t *testing.T) {
-	h := newHeap32(16)
-	for j := 0; j < 8; j++ {
-		h.Push(rand(j), uint32(j))
-	}
-
-	val, _ := h.Pop()
-	for j := 1; j < 128; j++ {
-		newval, ok := h.Pop()
-		if ok {
-			assert.True(t, val < newval)
-			val = newval
 		}
 	}
 }

--- a/point.go
+++ b/point.go
@@ -269,3 +269,35 @@ func (v Direction) String() string {
 func (v Direction) Vector(scale int16) Point {
 	return Point{}.MoveBy(v, scale)
 }
+
+// angleOf returns the direction from one point to another
+func angleOf(from, to Point) Direction {
+	dx := to.X - from.X
+	dy := to.Y - from.Y
+
+	switch {
+	case dx == 0 && dy == -1:
+		return North
+	case dx == 1 && dy == -1:
+		return NorthEast
+	case dx == 1 && dy == 0:
+		return East
+	case dx == 1 && dy == 1:
+		return SouthEast
+	case dx == 0 && dy == 1:
+		return South
+	case dx == -1 && dy == 1:
+		return SouthWest
+	case dx == -1 && dy == 0:
+		return West
+	case dx == -1 && dy == -1:
+		return NorthWest
+	default:
+		return Direction(0) // Invalid direction
+	}
+}
+
+// oppositeDirection returns the opposite of the given direction
+func oppositeDirection(dir Direction) Direction {
+	return Direction((dir + 4) % 8)
+}


### PR DESCRIPTION
This pull request includes significant changes to the pathfinding logic in the `tile` package, focusing on improving performance and simplifying the codebase. The most important changes include replacing the heap-based priority queue with a bucket-based frontier, optimizing the pathfinding state management, and updating the benchmarks and tests to reflect these changes. Most of the changes are thanks to [quasilyte/pathing](https://github.com/quasilyte/pathing) (see deck [zero-alloc-pathfinding](https://speakerdeck.com/quasilyte/zero-alloc-pathfinding)). Replacing the heap with his priority queue and replacing the visited map with my int-int map simplified implementation and achieved general speedup of 5-40x, making me wonder what I was thinking when implementing this pathfinding a few years ago.

### Pathfinding Optimization:
* Replaced the heap-based priority queue with a bucket-based `frontier` for more efficient pathfinding (`path.go`, `point.go`). [[1]](diffhunk://#diff-e61f786c29a0c2a6197e3b26386a39928cac35327688e79ff0e98160fa45ad4aL28-R44) [[2]](diffhunk://#diff-e61f786c29a0c2a6197e3b26386a39928cac35327688e79ff0e98160fa45ad4aL66-R255) [[3]](diffhunk://#diff-b3419f941efd96f6d5f11d261d273cc4f0afa8560ed79b9885ae40dd18379e80R272-R303)
* Introduced a `pathfinder` struct to manage pathfinding state and optimized state acquisition and release using a sync pool (`path.go`). [[1]](diffhunk://#diff-e61f786c29a0c2a6197e3b26386a39928cac35327688e79ff0e98160fa45ad4aL28-R44) [[2]](diffhunk://#diff-e61f786c29a0c2a6197e3b26386a39928cac35327688e79ff0e98160fa45ad4aL66-R255)
* Replaced map-based edge storage with `intmap` for better performance and reduced memory usage (`path.go`). [[1]](diffhunk://#diff-e61f786c29a0c2a6197e3b26386a39928cac35327688e79ff0e98160fa45ad4aL28-R44) [[2]](diffhunk://#diff-e61f786c29a0c2a6197e3b26386a39928cac35327688e79ff0e98160fa45ad4aL66-R255)

### Benchmark and Test Updates:
* Updated benchmarks to reflect the performance improvements and added new benchmark results (`path_test.go`). [[1]](diffhunk://#diff-e65edbcd5a006378e11ec33d7b121f21a20ec2631433f0b75bfa54e11768e9caL54-R65) [[2]](diffhunk://#diff-e65edbcd5a006378e11ec33d7b121f21a20ec2631433f0b75bfa54e11768e9caL125-R136) [[3]](diffhunk://#diff-e65edbcd5a006378e11ec33d7b121f21a20ec2631433f0b75bfa54e11768e9caL178-R193)
* Modified test cases to accommodate changes in pathfinding logic and added debug output for path visualization (`path_test.go`). [[1]](diffhunk://#diff-e65edbcd5a006378e11ec33d7b121f21a20ec2631433f0b75bfa54e11768e9caL26-R32) [[2]](diffhunk://#diff-e65edbcd5a006378e11ec33d7b121f21a20ec2631433f0b75bfa54e11768e9caL43-R46)

### Dependency Update:
* Added `github.com/kelindar/intmap` dependency to the `go.mod` file.